### PR TITLE
狂三【刻弹】修改

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -1105,7 +1105,14 @@ export async function content(config,pack){
 		trigger: { player: 'useCardToTargeted' },
 		filter: function (event, player) {
 			var info = get.info(event.card);
-			return info && info.enhance && event.player.lili > info.enhance;
+			if(!(info && info.enhance)) return;
+			
+			if(event.player.hasSkillTag("preventLoseLili")){
+			    //阻止灵力消耗，比如狂三的符卡技"gezi_shishi"
+			    return true;
+			}else{
+			    return event.player.lili > info.enhance;
+			}
 		},
 		content: function () {
 			'step 0'
@@ -1136,7 +1143,9 @@ export async function content(config,pack){
 			}
 		},
 		check: function (event, player) {
+		    if(player.hasSkillTag("noCostLili")) return true;
 			if (player.lili < 2) return false;
+			
 			var card = event.card;
 			if (card.name == 'gezi_danmakucraze') {
 				return (player.countCards('h') < player.hp) || player.countCards('h', { name: 'sha' }) || player.hp >= 2;

--- a/source/package.js
+++ b/source/package.js
@@ -22311,6 +22311,10 @@ export const ext_package = {
 						if (card.name == 'sha') return Infinity;
 					},
 				},
+				ai:{
+				    preventLoseLili:true,
+				    //阻止灵力消耗
+				},
 			},
 			"gezi_shishi2": {
 				audio: "ext:东方project:2",


### PR DESCRIPTION
使狂三在符卡技持续时间也能使用【禁忌牌】的附加效果。（原来不能）